### PR TITLE
Docs and testing

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -7,3 +7,12 @@ plugins:
       extensions:
         - '.ts'
         - '.tsx'
+
+exclude_patterns:
+  - '**/node_modules/**'
+  - '**/test/**'
+  - '**/*.spec.ts'
+  - '**/*.test.ts'
+  - '**/*.spec.tsx'
+  - '**/*.test.tsx'
+  - '**/*.d.ts'

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,7 +38,10 @@
     },
     "rules": {
         "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
-        "@typescript-eslint/no-shadow": "warn"
+        "@typescript-eslint/no-shadow": "warn",
+        "react-hooks/exhaustive-deps": ["warn", {
+            "additionalHooks": "(useMeasuredCallback)"
+        }]
         // "indent": [
         //     "error",
         //     4

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A toolkit of useful React hooks.
 - [`useMeasuredCallback(callback, deps, onMeasure?)`](#usemeasuredcallbackcallback-deps-onmeasure)
 - [`useMount(effect)`](#usemounteffect)
 - [`useDidMount()`](#usedidmount)
+- [`useForceUpdate()`](#useforceupdate)
 
 ## `useFetch(url, fetchOptions)`
 
@@ -290,6 +291,40 @@ export const MyComponent: FC = () => {
     const isMounted = useDidMount()
     return (
         <span>MyComponent {isMounted ? 'is' : 'is not'} mounted to the DOM</span>
+    )
+}
+```
+
+----
+
+## `useForceUpdate()`
+
+Allows you to force a component to rerender whether or not React has detected a
+state change. The function returned by this hook will cause the rerender when
+called.
+
+### Example
+
+```tsx
+import { FC, useRef, useEffect } from 'react
+import { useForceUpdate } from '@donisaac/react-hooks'
+// Displays an update counter and a button to force an update. This is 
+// not exactly best practice, but it is a good example of how to use
+// this hook.
+const TestComponent: FC = () => {
+    const forceUpdate = useForceUpdate()
+    const updateCount = useRef(0)
+    // Increment the update counter on each rerender
+    useEffect(() => {
+       updateCount.current++
+    })
+    return (
+        <div>
+            <span data-testid="update-count" id="update-count">
+                {updateCount.current}
+            </span>
+            <button onClick={forceUpdate}>Force Update</button>
+        </div>
     )
 }
 ```

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
   },
   "devDependencies": {
     "@shopify/jest-dom-mocks": "^4.0.0",
+    "@testing-library/dom": "^8.13.0",
+    "@testing-library/react": "^13.3.0",
     "@testing-library/react-hooks": "^8.0.0",
     "@types/jest": "^28.1.1",
     "@types/jsdom": "^16.2.14",
@@ -53,6 +55,7 @@
     "jsdom": "^19.0.0",
     "prettier": "^2.7.0",
     "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "react-test-renderer": "^18.2.0",
     "rimraf": "^3.0.2",
     "synchronous-promise": "^2.0.15",

--- a/src/lib/deepEqual.spec.ts
+++ b/src/lib/deepEqual.spec.ts
@@ -50,6 +50,10 @@ describe('deepEqual(a, b)', () => {
         [1, 'hi'],
         [{ a: 1 }, { a: 2 }],
         [{ a: 1 }, { b: 1 }],
+        [
+            { a: 1, b: { c: { d: 'hello' } } },
+            { a: 1, b: { c: { d: 'world' } } },
+        ],
         ['hi', 'hello'],
         ['hi', 'Hi'],
     ])('deepEqual(%p, %p) === false', (a, b) => {

--- a/src/lib/deepEqual.spec.ts
+++ b/src/lib/deepEqual.spec.ts
@@ -18,14 +18,17 @@ describe('deepEqual(a, b)', () => {
             [1, 2, 3],
         ],
         [{ a: 1 }, { a: 1 }],
+        [{}, {}],
     ])('deepEqual(%p, %p) === true', (a, b) => {
         expect(deepEqual(a, b)).toBe(true)
+        expect(deepEqual(b, a)).toBe(true)
     })
 
     it.each([
         [1, 2],
         [null, undefined],
         [undefined, null],
+        [{}, null],
         [false, true],
         [true, false],
         [Symbol.for('foo'), Symbol.for('bar')],
@@ -39,6 +42,11 @@ describe('deepEqual(a, b)', () => {
             [1, 2, 3],
             ['1', '2', '3'],
         ],
+        [[], { a: 1 }],
+        [
+            [1, 2, 3],
+            [1, 2, 3, 4],
+        ],
         [1, 'hi'],
         [{ a: 1 }, { a: 2 }],
         [{ a: 1 }, { b: 1 }],
@@ -46,6 +54,7 @@ describe('deepEqual(a, b)', () => {
         ['hi', 'Hi'],
     ])('deepEqual(%p, %p) === false', (a, b) => {
         expect(deepEqual(a, b)).toBe(false)
+        expect(deepEqual(b, a)).toBe(false)
     })
 
     it('correctly handles deeply equal objects', () => {

--- a/src/lib/deepEqual.ts
+++ b/src/lib/deepEqual.ts
@@ -20,7 +20,7 @@ export default function deepEqual(a: unknown, b: unknown): boolean {
         if (typeof b !== 'object') return false
         // If a is nullish but a and b didn't pass the Object.is()
         // check, that means a is null and b is undefined or vice versa
-        if (a == null) return false
+        if (a == null || b == null) return false
         const aKeys = Object.keys(a).sort()
         const bKeys = Object.keys(b as object).sort()
         if (aKeys.length !== bKeys.length) return false

--- a/src/useForceUpdate.spec.tsx
+++ b/src/useForceUpdate.spec.tsx
@@ -1,0 +1,48 @@
+import React, { FC, useEffect, useRef } from 'react'
+import { act, render, RenderResult } from '@testing-library/react'
+import useForceUpdate from './useForceUpdate'
+
+const TestComponent: FC = () => {
+    const forceUpdate = useForceUpdate()
+    const updateCount = useRef(0)
+    useEffect(() => {
+        updateCount.current++
+    })
+
+    return (
+        <div>
+            <span data-testid="update-count" id="update-count">
+                {updateCount.current}
+            </span>
+            <button onClick={forceUpdate}>Force Update</button>
+        </div>
+    )
+}
+
+describe('useForceUpdate()', () => {
+    let result: RenderResult
+
+    beforeEach(() => {
+        result = render(<TestComponent />)
+    })
+
+    afterEach(() => {
+        result.unmount()
+    })
+
+    it('update count starts at 0', () => {
+        const updateCount = result.getByTestId('update-count')
+        expect(updateCount).toBeDefined()
+        expect(updateCount.textContent).toBe('0')
+    })
+
+    it('update count increases after force update', () => {
+        const updateCount = result.getByTestId('update-count')
+        const forceUpdateButton = result.getByText('Force Update')
+        act(() => {
+            forceUpdateButton.click()
+        })
+
+        expect(updateCount.textContent).toBe('1')
+    })
+})

--- a/src/useForceUpdate.ts
+++ b/src/useForceUpdate.ts
@@ -12,7 +12,7 @@ const MAX_STATE_VALUE = 100
  * import { FC, useRef, useEffect } from 'react
  * import { useForceUpdate } from '@donisaac/react-hooks'
  *
- * // Displays an update counter and a button to force an update. This is 
+ * // Displays an update counter and a button to force an update. This is
  * // not exactly best practice, but it is a good example of how to use
  * // this hook.
  * const TestComponent: FC = () => {

--- a/src/useForceUpdate.ts
+++ b/src/useForceUpdate.ts
@@ -2,6 +2,41 @@ import { useState, useCallback } from 'react'
 
 const MAX_STATE_VALUE = 100
 
+/**
+ * Forces a component to update.
+ *
+ * This is useful for forcing updates when deeply nested state changes occur.
+ *
+ * @example
+ * ```tsx
+ * import { FC, useRef, useEffect } from 'react
+ * import { useForceUpdate } from '@donisaac/react-hooks'
+ *
+ * // Displays an update counter and a button to force an update. This is 
+ * // not exactly best practice, but it is a good example of how to use
+ * // this hook.
+ * const TestComponent: FC = () => {
+ *     const forceUpdate = useForceUpdate()
+ *     const updateCount = useRef(0)
+ *
+ *     // Increment the update counter on each rerender
+ *     useEffect(() => {
+ *        updateCount.current++
+ *     })
+ *
+ *     return (
+ *         <div>
+ *             <span data-testid="update-count" id="update-count">
+ *                 {updateCount.current}
+ *             </span>
+ *             <button onClick={forceUpdate}>Force Update</button>
+ *         </div>
+ *     )
+ * }
+ * ```
+ *
+ * @returns a function that forces a component to update
+ */
 export default function useForceUpdate(): () => void {
     const [_, setState] = useState(0)
     const forceUpdate = useCallback(

--- a/src/useInterval.spec.ts
+++ b/src/useInterval.spec.ts
@@ -41,4 +41,16 @@ describe('useInterval(cb, delay)', () => {
         clock.tick(500)
         expect(cb).toHaveBeenCalledTimes(3)
     })
+
+    it('does not call the callback after unmount', () => {
+        const cb = jest.fn()
+        const { unmount, rerender } = renderHook(() => useInterval(cb, 1000))
+
+        rerender()
+        expect(cb).not.toHaveBeenCalled()
+
+        unmount()
+        clock.tick(2000)
+        expect(cb).not.toHaveBeenCalled()
+    })
 })

--- a/src/useMeasuredCallback.spec.ts
+++ b/src/useMeasuredCallback.spec.ts
@@ -1,0 +1,101 @@
+import { renderHook, RenderHookResult } from '@testing-library/react-hooks'
+import { sleep } from './lib/util'
+import useMeasuredCallback from './useMeasuredCallback'
+
+describe('useMeasuredCallback(cb, deps, onMeasure)', () => {
+    const onMeasure = jest.fn()
+    let callback: jest.Mock<unknown>
+    let result: RenderHookResult<unknown, (...args: any[]) => unknown>
+
+    beforeEach(() => {
+        result = renderHook(() => useMeasuredCallback(callback, [], onMeasure))
+    })
+
+    afterEach(() => {
+        result.unmount()
+        onMeasure.mockClear()
+        callback?.mockClear()
+    })
+
+    describe('given a callback that returns a string', () => {
+        beforeAll(() => {
+            callback = jest.fn(() => 'foo')
+        })
+
+        afterAll(() => {
+            callback = undefined as any
+        })
+
+        it('returns a function', () => {
+            expect(result.result.current).toBeInstanceOf(Function)
+        })
+
+        describe('when the returned function is called', () => {
+            let returnedValue: string
+
+            beforeEach(() => {
+                returnedValue = result.result.current(1, 'foo') as string
+            })
+
+            it('passes the arguments to the callback', () => {
+                expect(callback).toHaveBeenCalledWith(1, 'foo')
+            })
+
+            it('returns the callback return value', () => {
+                expect(returnedValue).toBe('foo')
+            })
+
+            it('invokes onMeasure with the captured PerformanceMeasure object', () => {
+                expect(onMeasure).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        duration: expect.any(Number),
+                        entryType: 'measure',
+                        name: expect.any(String),
+                        startTime: expect.any(Number),
+                    })
+                )
+            })
+        })
+    })
+
+    describe('given a callback that returns a promise that resolves to a string', () => {
+        beforeAll(() => {
+            callback = jest.fn(() => sleep(50).then(() => 'foo'))
+        })
+
+        afterAll(() => {
+            callback = undefined as any
+        })
+
+        it('returns a function', () => {
+            expect(result.result.current).toBeInstanceOf(Function)
+        })
+
+        describe('when the returned function is called', () => {
+            let returnedValue: Promise<string>
+
+            beforeEach(() => {
+                returnedValue = result.result.current(
+                    1,
+                    'foo'
+                ) as Promise<string>
+            })
+
+            it('passes the arguments to the callback', () => {
+                expect(callback).toHaveBeenCalledWith(1, 'foo')
+            })
+
+            it('returns the callback return value', async () => {
+                expect(returnedValue).toBeInstanceOf(Promise)
+                const awaitedReturnedValue = await returnedValue
+                expect(awaitedReturnedValue).toBe('foo')
+            })
+
+            it('invoked onMeasure once the promise resolves', async () => {
+                expect(onMeasure).not.toHaveBeenCalled()
+                await returnedValue
+                expect(onMeasure).toHaveBeenCalled()
+            })
+        })
+    })
+})

--- a/src/useMemoCompare.ts
+++ b/src/useMemoCompare.ts
@@ -3,7 +3,26 @@ import deepEqual from './lib/deepEqual'
 
 export type Compare<T> = (a: T, b: T) => boolean
 
-// Shamelessly stolen from useHooks.com
+/**
+ * Similar to [useMemo], this hook memoizes an object by comparing it
+ * with a {@link Compare comparison function}. This hook doesn't aim to
+ * avoid expensive computation, rather it aims to provide a stable value
+ * for a deeply nested object so that it can be used within a dependency
+ * array.
+ *
+ * This hook was inspired by useHook's
+ * [useMemoCompare][https://usehooks.com/useMemoCompare], but the
+ * implementation is different.
+ *
+ * @param curr The current value of the object to memoize.
+ * @param compare A function that compares the current value of the object.
+ *        Defaults to {@link deepEqual}.
+ *
+ * @returns `curr` if it isn't equal to the previous value, otherwise
+ *          the previous value.
+ *
+ * @see [useHooks - useMemoCompare](https://usehooks.com/useMemoCompare)
+ */
 export default function useMemoCompare<T>(
     curr: T,
     compare: Compare<T> = deepEqual

--- a/test/setupTestsAfterEnv.ts
+++ b/test/setupTestsAfterEnv.ts
@@ -1,5 +1,61 @@
 import { ensureMocksReset } from '@shopify/jest-dom-mocks'
+import { assert } from 'console'
+import { performance, Performance, PerformanceEntry } from 'perf_hooks'
 
-afterEach(() => {
-    ensureMocksReset()
+const performanceMarkMock = jest.fn(performance.mark)
+
+global.performance = performance as any
+global.PerformanceEntry = PerformanceEntry as any
+class MockPerformanceMeasure
+    extends PerformanceEntry
+    implements PerformanceMeasure
+{
+    declare readonly detail: any
+    constructor() {
+        super()
+    }
+
+    toJSON() {
+        return {
+            duration: 0,
+            entryType: 'measure',
+            name: '',
+            startTime: 0,
+        }
+    }
+}
+Object.defineProperty(global, 'PerformanceMeasure', {
+    value: MockPerformanceMeasure,
+    writable: true,
+    enumerable: true,
+    configurable: true,
 })
+if (!global.performance.mark) {
+    global.performance.mark = performance.mark as any
+}
+if (!global.performance.measure) {
+    global.performance.measure = performance.measure as any
+}
+
+if (window) {
+    window.performance = performance as any
+}
+// global.performance = performance as unknown as Window['performance']
+// if (!global.performance.mark) {
+//     global.performance.mark = performanceMarkMock
+// }
+
+// if (window && !window.performance) {
+//     window.performance = performance as unknown as Window['performance']
+//     if (!window.performance.mark) {
+//         performanceMarkMock = jest.fn()
+//         window.performance.mark = performanceMarkMock
+//     }
+// }
+
+// afterEach(() => {
+//     ensureMocksReset()
+//     if (performanceMarkMock) {
+//         performanceMarkMock.mockClear()
+//     }
+// })

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,7 +14,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.16.7":
+"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.16.7":
   version: 7.16.7
   resolution: "@babel/code-frame@npm:7.16.7"
   dependencies:
@@ -575,6 +575,8 @@ __metadata:
   resolution: "@donisaac/react-hooks@workspace:."
   dependencies:
     "@shopify/jest-dom-mocks": ^4.0.0
+    "@testing-library/dom": ^8.13.0
+    "@testing-library/react": ^13.3.0
     "@testing-library/react-hooks": ^8.0.0
     "@types/jest": ^28.1.1
     "@types/jsdom": ^16.2.14
@@ -595,6 +597,7 @@ __metadata:
     jsdom: ^19.0.0
     prettier: ^2.7.0
     react: ^18.2.0
+    react-dom: ^18.2.0
     react-test-renderer: ^18.2.0
     rimraf: ^3.0.2
     synchronous-promise: ^2.0.15
@@ -1044,6 +1047,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/dom@npm:^8.13.0, @testing-library/dom@npm:^8.5.0":
+  version: 8.13.0
+  resolution: "@testing-library/dom@npm:8.13.0"
+  dependencies:
+    "@babel/code-frame": ^7.10.4
+    "@babel/runtime": ^7.12.5
+    "@types/aria-query": ^4.2.0
+    aria-query: ^5.0.0
+    chalk: ^4.1.0
+    dom-accessibility-api: ^0.5.9
+    lz-string: ^1.4.4
+    pretty-format: ^27.0.2
+  checksum: 880f1872b9949800d4444e3bdbd03df86d6f41ec7c27136dff1da29e87d2df2d7ee904afcdf895ffce351c25bd12119117eae023354d50e707ad56d43b2ed3ed
+  languageName: node
+  linkType: hard
+
 "@testing-library/react-hooks@npm:^8.0.0":
   version: 8.0.0
   resolution: "@testing-library/react-hooks@npm:8.0.0"
@@ -1063,6 +1082,20 @@ __metadata:
     react-test-renderer:
       optional: true
   checksum: f45bd06601bf1d00e375c3d945b0e54b4d997b18402c45711deada7e8c4a8f569fe283973e6786c9ecd55e4bd01a43bd42546a2924453065880abf4b13dbafdb
+  languageName: node
+  linkType: hard
+
+"@testing-library/react@npm:^13.3.0":
+  version: 13.3.0
+  resolution: "@testing-library/react@npm:13.3.0"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+    "@testing-library/dom": ^8.5.0
+    "@types/react-dom": ^18.0.0
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  checksum: 98fd8616a7cae0ecfcbe97b5b3c5b91fbafccf449c04875395ccc0e3f0b139e53b3261b9536ec2169a5e2883a1be2098907209064061fe0c2ff21dfbc785dd40
   languageName: node
   linkType: hard
 
@@ -1098,6 +1131,13 @@ __metadata:
   version: 1.0.2
   resolution: "@tsconfig/node16@npm:1.0.2"
   checksum: ca94d3639714672bbfd55f03521d3f56bb6a25479bd425da81faf21f13e1e9d15f40f97377dedbbf477a5841c5b0c8f4cd1b391f33553d750b9202c54c2c07aa
+  languageName: node
+  linkType: hard
+
+"@types/aria-query@npm:^4.2.0":
+  version: 4.2.2
+  resolution: "@types/aria-query@npm:4.2.2"
+  checksum: 6f2ce11d91e2d665f3873258db19da752d91d85d3679eb5efcdf9c711d14492287e1e4eb52613b28e60375841a9e428594e745b68436c963d8bad4bf72188df3
   languageName: node
   linkType: hard
 
@@ -1250,6 +1290,15 @@ __metadata:
   version: 15.7.4
   resolution: "@types/prop-types@npm:15.7.4"
   checksum: ef6e1899e59b876c273811b1bd845022fc66d5a3d11cb38a25b6c566b30514ae38fe20a40f67622f362a4f4f7f9224e22d8da101cff3d6e97e11d7b4c307cfc1
+  languageName: node
+  linkType: hard
+
+"@types/react-dom@npm:^18.0.0":
+  version: 18.0.5
+  resolution: "@types/react-dom@npm:18.0.5"
+  dependencies:
+    "@types/react": "*"
+  checksum: cd48b81950f499b52a3f0c08261f00046f9b7c96699fa249c9664e257e820daf6ecac815cd1028cebc9d105094adc39d047d1efd79214394b8b2d515574c0787
   languageName: node
   linkType: hard
 
@@ -1645,6 +1694,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"aria-query@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "aria-query@npm:5.0.0"
+  checksum: c41f98866c5a304561ee8cae55856711cddad6f3f85d8cb43cc5f79667078d9b8979ce32d244c1ff364e6463a4d0b6865804a33ccc717fed701b281cf7dc6296
+  languageName: node
+  linkType: hard
+
 "array-includes@npm:^3.1.3":
   version: 3.1.4
   resolution: "array-includes@npm:3.1.4"
@@ -1950,7 +2006,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.0":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -2312,6 +2368,13 @@ __metadata:
   dependencies:
     esutils: ^2.0.2
   checksum: fd7673ca77fe26cd5cba38d816bc72d641f500f1f9b25b83e8ce28827fe2da7ad583a8da26ab6af85f834138cf8dae9f69b0cd6ab925f52ddab1754db44d99ce
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.5.9":
+  version: 0.5.14
+  resolution: "dom-accessibility-api@npm:0.5.14"
+  checksum: 782c813f75a09ba6735ef03b5e1624406a3829444ae49d5bdedd272a49d437ae3354f53e02ffc8c9fd9165880250f41546538f27461f839dd4ea1234e77e8d5e
   languageName: node
   linkType: hard
 
@@ -4326,6 +4389,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lz-string@npm:^1.4.4":
+  version: 1.4.4
+  resolution: "lz-string@npm:1.4.4"
+  bin:
+    lz-string: bin/bin.js
+  checksum: 54e31238a61a84d8f664d9860a9fba7310c5b97a52c444f80543069bc084815eff40b8d4474ae1d93992fdf6c252dca37cf27f6adbeb4dbc3df2f3ac773d0e61
+  languageName: node
+  linkType: hard
+
 "make-dir@npm:^3.0.0":
   version: 3.1.0
   resolution: "make-dir@npm:3.1.0"
@@ -4941,7 +5013,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:^27.0.0, pretty-format@npm:^27.5.1":
+"pretty-format@npm:^27.0.0, pretty-format@npm:^27.0.2, pretty-format@npm:^27.5.1":
   version: 27.5.1
   resolution: "pretty-format@npm:27.5.1"
   dependencies:
@@ -5043,6 +5115,18 @@ __metadata:
   version: 1.2.3
   resolution: "queue-microtask@npm:1.2.3"
   checksum: b676f8c040cdc5b12723ad2f91414d267605b26419d5c821ff03befa817ddd10e238d22b25d604920340fd73efd8ba795465a0377c4adf45a4a41e4234e42dc4
+  languageName: node
+  linkType: hard
+
+"react-dom@npm:^18.2.0":
+  version: 18.2.0
+  resolution: "react-dom@npm:18.2.0"
+  dependencies:
+    loose-envify: ^1.1.0
+    scheduler: ^0.23.0
+  peerDependencies:
+    react: ^18.2.0
+  checksum: 7d323310bea3a91be2965f9468d552f201b1c27891e45ddc2d6b8f717680c95a75ae0bc1e3f5cf41472446a2589a75aed4483aee8169287909fcd59ad149e8cc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
docs: Add `useForceUpdate` to `README`
docs: Add `useForceUpdate` JSDoc comment
test: Add `useForceUpdate` spec
test: Add `useMeasuredCallback` spec
docs: Add `useMemoCompare` JSDoc comment
test: Add `useMemoCompare` spec
fix: `deepEqual` throws error when the first argument is an object and the second argument is `null`
